### PR TITLE
Verify linkage of all components to the main dashboard

### DIFF
--- a/scripts/verify_file_structure.py
+++ b/scripts/verify_file_structure.py
@@ -47,7 +47,24 @@ def verify_component_linkage():
         if not os.path.isfile(component):
             print(f"Component linkage missing: {component}")
 
+def verify_linkage_to_main_dashboard():
+    components = [
+        "src/app.py",
+        "src/custom_dashboards.py",
+        "src/dashboard_update_manager.py",
+        "src/alerts_notifications.py",
+        "src/dashboard/adware_dashboard/core/adware_manager.py",
+        "src/dashboard/adware_dashboard/core/ai_integration.py",
+        "src/dashboard/adware_dashboard/core/deployment_manager.py"
+    ]
+    for component in components:
+        if not os.path.isfile(component):
+            print(f"Component linkage missing: {component}")
+        else:
+            print(f"Component {component} is properly linked to the main dashboard.")
+
 if __name__ == "__main__":
     base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     verify_structure(base_path, EXPECTED_STRUCTURE)
     verify_component_linkage()
+    verify_linkage_to_main_dashboard()

--- a/src/app.py
+++ b/src/app.py
@@ -62,6 +62,7 @@ class C2Dashboard:
         self.dashboard_update_manager.trigger_dashboard_update()
         self.alerts_notifications.integrate_with_main_gui(self)
         self.automated_incident_response.integrate_with_main_gui(self)
+        self.verify_component_linkage()
 
     def create_widgets(self):
         self.tab_control = ttk.Notebook(self.root)
@@ -957,6 +958,27 @@ class C2Dashboard:
 
         # Ensure all components are accessible and functional
         self.verify_components_linked()
+
+    def verify_component_linkage(self):
+        components = [
+            self.custom_dashboards,
+            self.dashboard_update_manager,
+            self.alerts_notifications,
+            self.automated_incident_response,
+            self.adware_manager,
+            self.ai_integration,
+            self.deployment_manager,
+            self.vulnerability_scanner,
+            self.exploit_payloads,
+            self.session_manager,
+            self.exploit_manager,
+            self.network_handler,
+            self.ai_agent
+        ]
+        for component in components:
+            if not component:
+                raise ValueError(f"Component {component} is not properly linked.")
+        messagebox.showinfo("Verification", "All components are properly linked and functional.")
 
 if __name__ == "__main__":
     root = tk.Tk()

--- a/src/dashboard/adware_dashboard/core/adware_manager.py
+++ b/src/dashboard/adware_dashboard/core/adware_manager.py
@@ -34,3 +34,14 @@ class AdwareManager:
         if not self.exploit_payloads or not self.network_exploitation or not self.adware_configurations:
             raise ValueError("AdwareManager is not properly linked to the main dashboard.")
         self.logger.info("AdwareManager is properly linked to the main dashboard.")
+
+    def verify_component_linkage(self):
+        components = [
+            self.exploit_payloads,
+            self.network_exploitation,
+            self.adware_configurations
+        ]
+        for component in components:
+            if not component:
+                raise ValueError(f"Component {component} is not properly linked.")
+        self.logger.info("All components are properly linked and functional.")

--- a/src/dashboard/adware_dashboard/core/ai_integration.py
+++ b/src/dashboard/adware_dashboard/core/ai_integration.py
@@ -5,6 +5,7 @@ class AIIntegration:
         self.logger = logger
         self.ai_configurations = []
         self.verify_linked()
+        self.verify_component_linkage()
 
     def generate_ai_config(self, model_name: str, parameters: dict):
         ai_config = {
@@ -25,6 +26,15 @@ class AIIntegration:
             raise ValueError("AIIntegration is not properly linked to the main dashboard.")
         self.logger.info("AIIntegration is properly linked to the main dashboard.")
         # Ensure all components are covered
+        components = [
+            self.ai_configurations
+        ]
+        for component in components:
+            if not component:
+                raise ValueError(f"Component {component} is not properly linked.")
+        self.logger.info("All components are properly linked and functional.")
+
+    def verify_component_linkage(self):
         components = [
             self.ai_configurations
         ]

--- a/src/dashboard/adware_dashboard/core/deployment_manager.py
+++ b/src/dashboard/adware_dashboard/core/deployment_manager.py
@@ -5,6 +5,7 @@ class DeploymentManager:
         self.logger = logger
         self.deployment_methods = []
         self.verify_linked()
+        self.verify_component_linkage()
 
     def add_deployment_method(self, method_name: str, config: dict):
         deployment_method = {
@@ -34,6 +35,15 @@ class DeploymentManager:
             raise ValueError("DeploymentManager is not properly linked to the main dashboard.")
         self.logger.info("DeploymentManager is properly linked to the main dashboard.")
         # Ensure all components are covered
+        components = [
+            self.deployment_methods
+        ]
+        for component in components:
+            if not component:
+                raise ValueError(f"Component {component} is not properly linked.")
+        self.logger.info("All components are properly linked and functional.")
+
+    def verify_component_linkage(self):
         components = [
             self.deployment_methods
         ]

--- a/src/dashboard_update_manager.py
+++ b/src/dashboard_update_manager.py
@@ -81,3 +81,14 @@ class DashboardUpdateManager:
         self.ensure_updates_reflected()
         # Add additional verification logic if needed
         return True
+
+    def verify_component_linkage(self):
+        components = [
+            "AdwareManager",
+            "AIIntegration",
+            "DeploymentManager"
+        ]
+        for component in components:
+            if not hasattr(self, component.lower()):
+                raise ValueError(f"Component {component} is not properly linked.")
+        self.logger.info("All components are properly linked and functional.")


### PR DESCRIPTION
Add methods to verify the linkage of all components to the main dashboard.

* **src/app.py**
  - Add `verify_component_linkage` method to check if all components are properly linked.
  - Call `verify_component_linkage` after initializing all components.

* **src/dashboard_update_manager.py**
  - Add `verify_component_linkage` method to check if all components are properly linked.

* **src/dashboard/adware_dashboard/core/adware_manager.py**
  - Add `verify_component_linkage` method to check if all components are properly linked.

* **src/dashboard/adware_dashboard/core/ai_integration.py**
  - Add `verify_component_linkage` method to check if all components are properly linked.
  - Call `verify_component_linkage` after initializing the `AIIntegration` class.

* **src/dashboard/adware_dashboard/core/deployment_manager.py**
  - Add `verify_component_linkage` method to check if all components are properly linked.
  - Call `verify_component_linkage` after initializing the `DeploymentManager` class.

* **scripts/verify_file_structure.py**
  - Add `verify_linkage_to_main_dashboard` method to check if all components are properly linked to the main dashboard.
  - Call `verify_linkage_to_main_dashboard` after verifying the file structure.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ProjectZeroDays/AI-Driven-Zero-Click-Exploit-Deployment-Framework/pull/59?shareId=ff08f52a-ea98-4e0e-9d7c-752462726746).