### PR TITLE
Update actions/upload-artifact version in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         tags: user/repository:latest
 
     - name: Upload deployment logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: deployment-logs
         path: logs/deployment.log

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ To capture and store logs as artifacts in your GitHub Actions workflows, follow 
 
    ```yaml
    - name: Upload deployment logs
-     uses: actions/upload-artifact@v2
+     uses: actions/upload-artifact@v3
      with:
        name: deployment-logs
        path: logs/deployment.log


### PR DESCRIPTION
Update the `actions/upload-artifact` version in the workflow file.

* Change the `uses` field in the "Upload deployment logs" step from `actions/upload-artifact@v2` to `actions/upload-artifact@v3` in `.github/workflows/deploy.yml`.
* Update the `README.md` to reflect the new version of `actions/upload-artifact` from `v2` to `v3`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ProjectZeroDays/AI-Driven-Zero-Click-Exploit-Deployment-Framework/pull/99?shareId=7c866335-3f0f-4578-8f55-2341a6d47686).