### PR TITLE
Fix upload deployment logs step in workflow

### DIFF
--- a/src/.github/workflows/deploy.yml
+++ b/src/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         name: deployment-logs
         path: logs/deployment.log
-        distribution: your-distribution-input  # P3e36, P68c0
+        distribution: ubuntu-latest  # P3e36, P68c0
 
     - name: Notify on CI/CD pipeline failure
       if: failure()


### PR DESCRIPTION
Replace the `your-distribution-input` placeholder with `ubuntu-latest` in the `Upload deployment logs` step.

* Update `src/.github/workflows/deploy.yml` to specify `ubuntu-latest` for the `distribution` input in the `Upload deployment logs` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ProjectZeroDays/AI-Driven-Zero-Click-Exploit-Deployment-Framework/pull/102?shareId=446312fa-b76a-42df-b670-6ce5182f2fd1).