### PR TITLE
Add API key security to endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,7 @@ ENV ENCRYPTION_METHOD=AES-256
 # Add configurations for blockchain-based logging systems
 ENV BLOCKCHAIN_LOGGING_ENABLED=True
 ENV BLOCKCHAIN_LOGGING_NODE=http://localhost:8545
+
+# Add API_KEY and API_SECRET environment variables
+ENV API_KEY=${API_KEY}
+ENV API_SECRET=${API_SECRET}

--- a/config/config.py
+++ b/config/config.py
@@ -23,3 +23,7 @@ class Config:
     # Regular security audits and penetration testing
     SECURITY_AUDITS_ENABLED = os.environ.get('SECURITY_AUDITS_ENABLED', 'True') == 'True'
     PENETRATION_TESTING_ENABLED = os.environ.get('PENETRATION_TESTING_ENABLED', 'True') == 'True'
+
+    # API Key and Secret for production
+    API_KEY = os.environ.get('API_KEY')
+    API_SECRET = os.environ.get('API_SECRET')

--- a/src/backend/api/trojan_api.py
+++ b/src/backend/api/trojan_api.py
@@ -38,6 +38,7 @@ class TrojanClient(db.Model):
 
 # --- API Endpoints ---
 @app.route('/servers', methods=['GET', 'POST'])
+@require_api_key
 def manage_trojan_servers():
     logger.info(f"API request: {request.method} /servers")
     if request.method == 'GET':
@@ -64,6 +65,7 @@ def manage_trojan_servers():
             return jsonify({'message': 'Error creating trojan server', 'error': str(e)}), 500
 
 @app.route('/clients', methods=['GET', 'POST'])
+@require_api_key
 def manage_trojan_clients():
     logger.info(f"API request: {request.method} /clients")
     if request.method == 'GET':
@@ -90,6 +92,7 @@ def manage_trojan_clients():
             return jsonify({'message': 'Error creating trojan client', 'error': str(e)}), 500
 
 @app.route('/generate', methods=['POST'])
+@require_api_key
 def generate_trojan_config_api():
     logger.info(f"API request: {request.method} /generate")
     data = request.get_json()
@@ -111,6 +114,7 @@ def generate_trojan_config_api():
         return jsonify({'message': 'Error generating trojan config with AI', 'error': str(e)}), 500
 
 @app.route('/deploy/<int:trojan_id>', methods=['POST'])
+@require_api_key
 def deploy_trojan_api(trojan_id):
     logger.info(f"API request: {request.method} /deploy/{trojan_id}")
     trojan = TrojanServer.query.get(trojan_id) or TrojanClient.query.get(trojan_id)
@@ -131,6 +135,7 @@ def deploy_trojan_api(trojan_id):
         return jsonify({'message': f"Error deploying trojan: {str(e)}", 'error': str(e)}), 500
 
 @app.route('/ai_features', methods=['POST'])
+@require_api_key
 def ai_features():
     logger.info(f"API request: {request.method} /ai_features")
     data = request.get_json()
@@ -152,6 +157,7 @@ def ai_features():
         return jsonify({'message': 'Error processing AI-driven feature', 'error': str(e)}), 500
 
 @app.route('/security_measures', methods=['POST'])
+@require_api_key
 def security_measures():
     logger.info(f"API request: {request.method} /security_measures")
     data = request.get_json()
@@ -173,6 +179,7 @@ def security_measures():
         return jsonify({'message': 'Error implementing security measure', 'error': str(e)}), 500
 
 @app.route('/vulnerability_scan', methods=['POST'])
+@require_api_key
 def vulnerability_scan():
     logger.info(f"API request: {request.method} /vulnerability_scan")
     data = request.get_json()
@@ -193,6 +200,7 @@ def vulnerability_scan():
         return jsonify({'message': 'Error during AI-driven vulnerability scanning', 'error': str(e)}), 500
 
 @app.route('/exploit_modifications', methods=['POST'])
+@require_api_key
 def exploit_modifications():
     logger.info(f"API request: {request.method} /exploit_modifications")
     data = request.get_json()
@@ -213,6 +221,7 @@ def exploit_modifications():
         return jsonify({'message': 'Error during AI-driven exploit modifications', 'error': str(e)}), 500
 
 @app.route('/mfa', methods=['POST'])
+@require_api_key
 def multi_factor_authentication():
     logger.info(f"API request: {request.method} /mfa")
     data = request.get_json()
@@ -234,6 +243,7 @@ def multi_factor_authentication():
         return jsonify({'message': 'Error during MFA validation', 'error': str(e)}), 500
 
 @app.route('/blockchain_logging', methods=['POST'])
+@require_api_key
 def blockchain_logging():
     logger.info(f"API request: {request.method} /blockchain_logging")
     data = request.get_json()
@@ -254,6 +264,7 @@ def blockchain_logging():
         return jsonify({'message': 'Error during blockchain logging', 'error': str(e)}), 500
 
 @app.route('/agent_zero', methods=['POST'])
+@require_api_key
 def agent_zero_integration():
     logger.info(f"API request: {request.method} /agent_zero")
     data = request.get_json()
@@ -275,6 +286,7 @@ def agent_zero_integration():
         return jsonify({'message': 'Error during Agent Zero action', 'error': str(e)}), 500
 
 @app.route('/ai_asynchronous_processing', methods=['POST'])
+@require_api_key
 async def ai_asynchronous_processing():
     logger.info(f"API request: {request.method} /ai_asynchronous_processing")
     data = request.get_json()
@@ -298,6 +310,7 @@ async def ai_asynchronous_processing():
         return jsonify({'message': 'Error during AI-driven asynchronous processing', 'error': str(e)}), 500
 
 @app.route('/resource_management', methods=['POST'])
+@require_api_key
 async def resource_management():
     logger.info(f"API request: {request.method} /resource_management")
     try:
@@ -310,6 +323,7 @@ async def resource_management():
         return jsonify({'message': 'Error during AI-driven resource management', 'error': str(e)}), 500
 
 @app.route('/adjust_alert_thresholds', methods=['POST'])
+@require_api_key
 async def adjust_alert_thresholds_api():
     logger.info(f"API request: {request.method} /adjust_alert_thresholds")
     try:
@@ -322,6 +336,7 @@ async def adjust_alert_thresholds_api():
         return jsonify({'message': 'Error during AI-driven alert threshold adjustment', 'error': str(e)}), 500
 
 @app.route('/device_control', methods=['POST'])
+@require_api_key
 def device_control():
     logger.info(f"API request: {request.method} /device_control")
     data = request.get_json()
@@ -343,6 +358,7 @@ def device_control():
         return jsonify({'message': 'Error during device control panel integration', 'error': str(e)}), 500
 
 @app.route('/ai_dashboard_integration', methods=['POST'])
+@require_api_key
 def ai_dashboard_integration():
     logger.info(f"API request: {request.method} /ai_dashboard_integration")
     data = request.get_json()
@@ -364,6 +380,7 @@ def ai_dashboard_integration():
         return jsonify({'message': 'Error during AI dashboard integration', 'error': str(e)}), 500
 
 @app.route('/real_time_threat_intelligence', methods=['POST'])
+@require_api_key
 def real_time_threat_intelligence():
     logger.info(f"API request: {request.method} /real_time_threat_intelligence")
     data = request.get_json()
@@ -384,6 +401,7 @@ def real_time_threat_intelligence():
         return jsonify({'message': 'Error processing real-time threat intelligence', 'error': str(e)}), 500
 
 @app.route('/advanced_payload_delivery', methods=['POST'])
+@require_api_key
 def advanced_payload_delivery():
     logger.info(f"API request: {request.method} /advanced_payload_delivery")
     data = request.get_json()
@@ -404,6 +422,7 @@ def advanced_payload_delivery():
         return jsonify({'message': 'Error processing advanced payload delivery', 'error': str(e)}), 500
 
 @app.route('/security_audits', methods=['POST'])
+@require_api_key
 def security_audits():
     logger.info(f"API request: {request.method} /security_audits")
     data = request.get_json()
@@ -425,6 +444,7 @@ def security_audits():
         return jsonify({'message': 'Error conducting security audit', 'error': str(e)}), 500
 
 @app.route('/penetration_testing', methods=['POST'])
+@require_api_key
 def penetration_testing():
     logger.info(f"API request: {request.method} /penetration_testing")
     data = request.get_json()
@@ -770,6 +790,33 @@ def conduct_penetration_testing(test_type, parameters):
         'parameters': parameters,
         'result': 'Penetration testing conducted successfully'
     }
+
+def require_api_key(f):
+    """
+    Decorator to enforce API key requirement for endpoints.
+    """
+    @functools.wraps(f)
+    def decorated_function(*args, **kwargs):
+        api_key = request.headers.get('X-API-Key')
+        if api_key:
+            logger.info(f"API key provided: {api_key}")
+            if settings_manager:
+                try:
+                    if api_key == settings_manager.get_setting("general", "api_key"):
+                        return f(*args, **kwargs)
+                    else:
+                        logger.warning("Invalid API key provided")
+                        return jsonify({"error": "Unauthorized"}), 401
+                except Exception as e:
+                    logger.error(f"Error validating API key: {e}")
+                    return jsonify({"error": "Internal Server Error"}), 500
+            else:
+                logger.error("SettingsManager is not initialized")
+                return jsonify({"error": "Internal Server Error"}), 500
+        else:
+            logger.warning("No API key provided")
+            return jsonify({"error": "Unauthorized"}), 401
+    return decorated_function
 
 if __name__ == '__main__':
     with app.app_context():

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -28,6 +28,8 @@ except Exception as e:
 # Database Configuration
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///trojan.db')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['API_KEY'] = os.environ.get('API_KEY')
+app.config['API_SECRET'] = os.environ.get('API_SECRET')
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 
@@ -46,6 +48,7 @@ class TrojanClient(db.Model):
 
 # --- API Endpoints ---
 @app.route('/servers', methods=['GET', 'POST'])
+@require_api_key
 def manage_trojan_servers():
     logger.info(f"API request: {request.method} /servers")
     if request.method == 'GET':
@@ -72,6 +75,7 @@ def manage_trojan_servers():
             return jsonify({'message': 'Error creating trojan server', 'error': str(e)}), 500
 
 @app.route('/clients', methods=['GET', 'POST'])
+@require_api_key
 def manage_trojan_clients():
     logger.info(f"API request: {request.method} /clients")
     if request.method == 'GET':
@@ -98,6 +102,7 @@ def manage_trojan_clients():
             return jsonify({'message': 'Error creating trojan client', 'error': str(e)}), 500
 
 @app.route('/generate', methods=['POST'])
+@require_api_key
 def generate_trojan_config_api():
     logger.info(f"API request: {request.method} /generate")
     data = request.get_json()
@@ -119,6 +124,7 @@ def generate_trojan_config_api():
         return jsonify({'message': 'Error generating trojan config with AI', 'error': str(e)}), 500
 
 @app.route('/deploy/<int:trojan_id>', methods=['POST'])
+@require_api_key
 def deploy_trojan_api(trojan_id):
     logger.info(f"API request: {request.method} /deploy/{trojan_id}")
     trojan = TrojanServer.query.get(trojan_id) or TrojanClient.query.get(trojan_id)
@@ -139,6 +145,7 @@ def deploy_trojan_api(trojan_id):
         return jsonify({'message': f'Error deploying trojan: {str(e)}', 'error': str(e)}), 500
 
 @app.route('/ai_features', methods=['POST'])
+@require_api_key
 def ai_features():
     logger.info(f"API request: {request.method} /ai_features")
     data = request.get_json()
@@ -160,6 +167,7 @@ def ai_features():
         return jsonify({'message': 'Error processing AI-driven feature', 'error': str(e)}), 500
 
 @app.route('/security_measures', methods=['POST'])
+@require_api_key
 def security_measures():
     logger.info(f"API request: {request.method} /security_measures")
     data = request.get_json()
@@ -181,6 +189,7 @@ def security_measures():
         return jsonify({'message': 'Error implementing security measure', 'error': str(e)}), 500
 
 @app.route('/vulnerability_scan', methods=['POST'])
+@require_api_key
 def vulnerability_scan():
     logger.info(f"API request: {request.method} /vulnerability_scan")
     data = request.get_json()
@@ -201,6 +210,7 @@ def vulnerability_scan():
         return jsonify({'message': 'Error during AI-driven vulnerability scanning', 'error': str(e)}), 500
 
 @app.route('/exploit_modifications', methods=['POST'])
+@require_api_key
 def exploit_modifications():
     logger.info(f"API request: {request.method} /exploit_modifications")
     data = request.get_json()
@@ -221,6 +231,7 @@ def exploit_modifications():
         return jsonify({'message': 'Error during AI-driven exploit modifications', 'error': str(e)}), 500
 
 @app.route('/mfa', methods=['POST'])
+@require_api_key
 def multi_factor_authentication():
     logger.info(f"API request: {request.method} /mfa")
     data = request.get_json()
@@ -242,6 +253,7 @@ def multi_factor_authentication():
         return jsonify({'message': 'Error during MFA validation', 'error': str(e)}), 500
 
 @app.route('/blockchain_logging', methods=['POST'])
+@require_api_key
 def blockchain_logging():
     logger.info(f"API request: {request.method} /blockchain_logging")
     data = request.get_json()
@@ -262,6 +274,7 @@ def blockchain_logging():
         return jsonify({'message': 'Error during blockchain logging', 'error': str(e)}), 500
 
 @app.route('/agent_zero', methods=['POST'])
+@require_api_key
 def agent_zero_integration():
     logger.info(f"API request: {request.method} /agent_zero")
     data = request.get_json()
@@ -283,6 +296,7 @@ def agent_zero_integration():
         return jsonify({'message': 'Error during Agent Zero action', 'error': str(e)}), 500
 
 @app.route('/ai_asynchronous_processing', methods=['POST'])
+@require_api_key
 async def ai_asynchronous_processing():
     logger.info(f"API request: {request.method} /ai_asynchronous_processing")
     data = request.get_json()
@@ -306,6 +320,7 @@ async def ai_asynchronous_processing():
         return jsonify({'message': 'Error during AI-driven asynchronous processing', 'error': str(e)}), 500
 
 @app.route('/resource_management', methods=['POST'])
+@require_api_key
 async def resource_management():
     logger.info(f"API request: {request.method} /resource_management")
     try:
@@ -318,6 +333,7 @@ async def resource_management():
         return jsonify({'message': 'Error during AI-driven resource management', 'error': str(e)}), 500
 
 @app.route('/adjust_alert_thresholds', methods=['POST'])
+@require_api_key
 async def adjust_alert_thresholds_api():
     logger.info(f"API request: {request.method} /adjust_alert_thresholds")
     try:
@@ -330,6 +346,7 @@ async def adjust_alert_thresholds_api():
         return jsonify({'message': 'Error during AI-driven alert threshold adjustment', 'error': str(e)}), 500
 
 @app.route('/device_control', methods=['POST'])
+@require_api_key
 def device_control():
     logger.info(f"API request: {request.method} /device_control")
     data = request.get_json()
@@ -351,6 +368,7 @@ def device_control():
         return jsonify({'message': 'Error during device control panel integration', 'error': str(e)}), 500
 
 @app.route('/ai_dashboard_integration', methods=['POST'])
+@require_api_key
 def ai_dashboard_integration():
     logger.info(f"API request: {request.method} /ai_dashboard_integration")
     data = request.get_json()

--- a/src/backend/core/config/settings_manager.py
+++ b/src/backend/core/config/settings_manager.py
@@ -110,3 +110,15 @@ class SettingsManager:
             "new_component_config": new_component_data.get("config", {})
         }
         return compatible_data
+
+    def get_api_key(self) -> str:
+        return self.get_setting("general", "api_key")
+
+    def set_api_key(self, api_key: str):
+        self.set_setting("general", "api_key", api_key)
+
+    def get_api_secret(self) -> str:
+        return self.get_setting("general", "api_secret")
+
+    def set_api_secret(self, api_secret: str):
+        self.set_setting("general", "api_secret", api_secret)


### PR DESCRIPTION
Add API key and secret environment variables and require API key for all API endpoints.

* **config/config.py**
  - Add `API_KEY` and `API_SECRET` environment variables to the `Config` class.

* **Dockerfile**
  - Add `API_KEY` and `API_SECRET` environment variables.

* **src/backend/app.py**
  - Add `require_api_key` decorator to all API endpoints.
  - Add `API_KEY` and `API_SECRET` to the `app.config`.

* **src/backend/core/config/settings_manager.py**
  - Add methods to get and set `API_KEY` and `API_SECRET`.

* **src/backend/api/trojan_api.py**
  - Add `require_api_key` decorator to all API endpoints.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ProjectZeroDays/AI-Driven-Zero-Click-Exploit-Deployment-Framework/pull/121?shareId=56a664a1-d312-4a4f-a837-ecfe45371651).